### PR TITLE
switched to a hybrid slub memory allocator

### DIFF
--- a/src/include/kernel/slab.h
+++ b/src/include/kernel/slab.h
@@ -1,0 +1,12 @@
+#ifndef _SLAB_H_
+#define _SLAB_H_
+
+void slab_init(void);
+
+void* slab_alloc(unsigned long size);
+void slab_free(void* ptr);
+
+// returns 1 if ptr was allocated by the slab allocator, 0 otherwise
+int slab_owns(void* ptr);
+
+#endif // _SLAB_H_

--- a/src/kernel/heap.c
+++ b/src/kernel/heap.c
@@ -1,9 +1,12 @@
 #include "kernel/heap.h"
+#include "kernel/slab.h"
 #include "kernel/lock.h"
 #include "kernel/pmm.h"
 #include "lib/stdio.h"
 #include "lib/panic.h"
 #include "kernel/timer.h"
+
+#define SLAB_MAX 1024 // allocations <= this go through the slab layer
 
 // each allocation is preceded by a block header
 struct block_header
@@ -39,6 +42,8 @@ static struct block_header* expand_heap(unsigned long min_size)
 
 void heap_init(void)
 {
+    slab_init();
+
     free_list = expand_heap(PAGE_SIZE);
     if (!free_list)
     {
@@ -46,18 +51,21 @@ void heap_init(void)
         return;
     }
 
-    printf("[ HEAP ] First-fit allocator: %lu bytes initial pool\n", free_list->size);
+    printf("[ HEAP ] First-fit fallback: %lu bytes initial pool\n", free_list->size);
     printf("[ HEAP ] Header: %lu bytes, payload alignment: 16 bytes\n", (unsigned long)HEADER_SIZE);
 }
 
 void* kmalloc(unsigned long size)
 {
-    unsigned long int flags = spin_lock_irqsave(&heap_lock);
     if (size == 0)
-    {
-        spin_unlock_irqrestore(&heap_lock, flags);
         return 0;
-    }
+
+    // small allocations: O(1) slab path
+    if (size <= SLAB_MAX)
+        return slab_alloc(size);
+
+    // large allocations: first-fit fallback
+    unsigned long int flags = spin_lock_irqsave(&heap_lock);
 
     size = ALIGN(size);
 
@@ -129,12 +137,18 @@ void* kmalloc(unsigned long size)
 
 void kfree(void* ptr)
 {
-    unsigned long flags = spin_lock_irqsave(&heap_lock);
     if (!ptr)
+        return;
+
+    // if the slab allocator owns this pointer, free through slab
+    if (slab_owns(ptr))
     {
-        spin_unlock_irqrestore(&heap_lock, flags);
+        slab_free(ptr);
         return;
     }
+
+    // large-allocation free: first-fit path
+    unsigned long flags = spin_lock_irqsave(&heap_lock);
     struct block_header* block = (struct block_header*)((unsigned char*)ptr - HEADER_SIZE);
 
     if (block->free)

--- a/src/kernel/slab.c
+++ b/src/kernel/slab.c
@@ -1,0 +1,219 @@
+#include "kernel/slab.h"
+#include "kernel/pmm.h"
+#include "kernel/lock.h"
+#include "lib/stdio.h"
+#include "lib/panic.h"
+
+// ---------------------------------------------------------------------------
+// Size-class slab allocator
+//
+// Each size class owns a pool of PAGE_SIZE slabs.  Every slab is carved into
+// fixed-size slots.  A per-slot freelist provides O(1) alloc/free with zero
+// per-object header overhead.  Each size class has its own spinlock so
+// different-class allocations never contend.
+//
+// Object -> slab lookup: mask off the low 12 bits of any pointer to get the
+// slab page, then read the slab_page header at the top of that page.
+// ---------------------------------------------------------------------------
+
+#define SLAB_MAGIC 0x534C4142U // "SLAB"
+
+// size classes: 16, 32, 64, 128, 256, 512, 1024
+#define NUM_CLASSES 7
+static const unsigned long class_size[NUM_CLASSES] = {16, 32, 64, 128, 256, 512, 1024};
+
+// free-list node embedded inside every free slot
+struct slab_obj
+{
+    struct slab_obj* next;
+};
+
+// per-page header living at the start of every slab page
+struct slab_page
+{
+    unsigned int magic;            // SLAB_MAGIC — used by slab_owns()
+    unsigned int class_idx;        // which size class this page belongs to
+    unsigned int total;            // total slots in this page
+    unsigned int in_use;           // currently allocated slots
+    struct slab_obj* free;         // per-page freelist head
+    struct slab_page* next;        // next slab page in this class
+};
+
+// per-class metadata
+struct slab_class
+{
+    unsigned long obj_size;        // slot size (bytes)
+    struct slab_page* partial;     // pages with free slots (alloc pops head → O(1))
+    struct slab_page* full;        // pages with no free slots
+    spinlock_t lock;
+};
+
+static struct slab_class classes[NUM_CLASSES];
+
+// ---------------------------------------------------------------------------
+// helpers
+// ---------------------------------------------------------------------------
+
+// given a pointer inside a slab page, recover the slab_page header
+static inline struct slab_page* ptr_to_slab(void* ptr)
+{
+    return (struct slab_page*)((unsigned long)ptr & ~(PAGE_SIZE - 1UL));
+}
+
+// return the class index for a given size, or -1 if too large
+static inline int size_to_class(unsigned long size)
+{
+    for (int i = 0; i < NUM_CLASSES; i++)
+        if (size <= class_size[i])
+            return i;
+    return -1;
+}
+
+// allocate a new slab page for the given class and prepend to partial list
+static struct slab_page* slab_grow(struct slab_class* sc, unsigned int idx)
+{
+    void* page = pmm_alloc_page();
+    if (!page)
+        return 0;
+
+    struct slab_page* sp = (struct slab_page*)page;
+    sp->magic = SLAB_MAGIC;
+    sp->class_idx = idx;
+    sp->in_use = 0;
+    sp->free = 0;
+
+    unsigned long obj_size = sc->obj_size;
+    // first slot starts right after the header, aligned to obj_size
+    unsigned long hdr = sizeof(struct slab_page);
+    unsigned long start = (hdr + obj_size - 1) & ~(obj_size - 1);
+
+    unsigned int count = 0;
+    for (unsigned long off = start; off + obj_size <= PAGE_SIZE; off += obj_size)
+    {
+        struct slab_obj* obj = (struct slab_obj*)((unsigned char*)page + off);
+        obj->next = sp->free;
+        sp->free = obj;
+        count++;
+    }
+    sp->total = count;
+
+    // new page has free slots → partial list
+    sp->next = sc->partial;
+    sc->partial = sp;
+    return sp;
+}
+
+// ---------------------------------------------------------------------------
+// public API
+// ---------------------------------------------------------------------------
+
+void slab_init(void)
+{
+    for (int i = 0; i < NUM_CLASSES; i++)
+    {
+        classes[i].obj_size = class_size[i];
+        classes[i].partial = 0;
+        classes[i].full = 0;
+        classes[i].lock = (spinlock_t)SPINLOCK_INIT;
+    }
+
+    // pre-allocate one slab page per class so early allocs don't fault
+    for (int i = 0; i < NUM_CLASSES; i++)
+    {
+        if (!slab_grow(&classes[i], (unsigned int)i))
+            PANIC("SLAB: Failed to grow class \n");
+    }
+
+    printf("[ SLAB ] %d size classes:", NUM_CLASSES);
+    for (int i = 0; i < NUM_CLASSES; i++)
+        printf(" %lu", class_size[i]);
+    printf(" bytes\n");
+    printf("[ SLAB ] Per-class spinlock, O(1) alloc/free, zero per-object overhead\n");
+}
+
+void* slab_alloc(unsigned long size)
+{
+    int idx = size_to_class(size);
+    if (idx < 0)
+        return 0; // too large for slab
+
+    struct slab_class* sc = &classes[idx];
+    unsigned long flags = spin_lock_irqsave(&sc->lock);
+
+    // O(1): grab head of partial list
+    struct slab_page* sp = sc->partial;
+
+    // no partial pages — grow
+    if (!sp)
+    {
+        sp = slab_grow(sc, (unsigned int)idx);
+        if (!sp)
+        {
+            spin_unlock_irqrestore(&sc->lock, flags);
+            PANIC("SLAB: Out of memory for class \n");
+            return 0;
+        }
+    }
+
+    // pop from freelist
+    struct slab_obj* obj = sp->free;
+    sp->free = obj->next;
+    sp->in_use++;
+
+    // if page is now full, move it from partial → full
+    if (!sp->free)
+    {
+        sc->partial = sp->next;
+        sp->next = sc->full;
+        sc->full = sp;
+    }
+
+    spin_unlock_irqrestore(&sc->lock, flags);
+    return (void*)obj;
+}
+
+void slab_free(void* ptr)
+{
+    if (!ptr)
+        return;
+
+    struct slab_page* sp = ptr_to_slab(ptr);
+    if (sp->magic != SLAB_MAGIC)
+        PANIC("SLAB: slab_free on non-slab pointer \n");
+
+    struct slab_class* sc = &classes[sp->class_idx];
+    unsigned long flags = spin_lock_irqsave(&sc->lock);
+
+    int was_full = (sp->free == 0);
+
+    // push back onto freelist
+    struct slab_obj* obj = (struct slab_obj*)ptr;
+    obj->next = sp->free;
+    sp->free = obj;
+    sp->in_use--;
+
+    // if page was full, move it from full → partial
+    if (was_full)
+    {
+        // unlink from full list
+        struct slab_page** prev = &sc->full;
+        while (*prev && *prev != sp)
+            prev = &(*prev)->next;
+        if (*prev)
+            *prev = sp->next;
+
+        // prepend to partial list
+        sp->next = sc->partial;
+        sc->partial = sp;
+    }
+
+    spin_unlock_irqrestore(&sc->lock, flags);
+}
+
+int slab_owns(void* ptr)
+{
+    if (!ptr)
+        return 0;
+    struct slab_page* sp = ptr_to_slab(ptr);
+    return sp->magic == SLAB_MAGIC;
+}

--- a/src/test/test.c
+++ b/src/test/test.c
@@ -19,6 +19,7 @@ void run_all_tests(void)
     test_string();
     test_spinlock();
     test_pmm();
+    test_slab();
     test_heap();
     test_timer();
     test_mmu();

--- a/src/test/test.h
+++ b/src/test/test.h
@@ -76,6 +76,7 @@ void test_string(void);
 // kernel tests
 void test_spinlock(void);
 void test_pmm(void);
+void test_slab(void);
 void test_heap(void);
 void test_timer(void);
 void test_mmu(void);

--- a/src/test/test_heap.c
+++ b/src/test/test_heap.c
@@ -4,6 +4,7 @@
 #include "lib/types.h"
 
 #define TEST_HEADER_SIZE 32 /* sizeof(block_header) */
+#define LARGE 2048              /* > SLAB_MAX (1024), forces first-fit path */
 
 void test_heap(void)
 {
@@ -140,25 +141,25 @@ void test_heap(void)
     }
     TEST_PASS("reuse same size");
 
-    // freed block reused for smaller alloc (fits in old block)
+    // freed block reused for smaller alloc (first-fit path, sizes > SLAB_MAX)
     {
-        void* p1 = kmalloc(256);
+        void* p1 = kmalloc(4096);
         kfree(p1);
-        void* p2 = kmalloc(16);
+        void* p2 = kmalloc(LARGE);
         // should reuse same address (first-fit), possibly splitting
         TEST_ASSERT("reuses for smaller", p2 == p1);
         kfree(p2);
     }
     TEST_PASS("reuse smaller alloc");
 
-    // first-fit: earlier free block chosen over later
+    // first-fit: earlier free block chosen over later (sizes > SLAB_MAX)
     {
-        void* a = kmalloc(64);
-        void* b = kmalloc(64);
-        void* c = kmalloc(64);
+        void* a = kmalloc(LARGE);
+        void* b = kmalloc(LARGE);
+        void* c = kmalloc(LARGE);
         kfree(a);
         kfree(c);
-        void* d = kmalloc(64);
+        void* d = kmalloc(LARGE);
         // first-fit should pick 'a' position
         TEST_ASSERT("first-fit picks earlier", d == a);
         kfree(d);
@@ -166,54 +167,56 @@ void test_heap(void)
     }
     TEST_PASS("first-fit ordering");
 
-    // block splitting
+    // block splitting (sizes > SLAB_MAX to exercise first-fit path)
 
     // split occurs when remainder >= header_size + 16 (48)
     //    Allocate a big block, free it, then allocate much smaller.
     //    The remainder should be split into a second usable block.
     {
-        void* big = kmalloc(256);
+        // Drain the initial pool so the freed block is the first-fit candidate.
+        // Initial pool is ~8160 bytes; allocating 8000 consumes it.
+        void* drain = kmalloc(8000);
+        void* big = kmalloc(8192);
         kfree(big);
-        // Freed block has size >= 256 (ALIGN(256)=256).
-        // Allocate 16 from it. Remainder = 256-16-32 = 208 >= 48 → splits.
-        void* small = kmalloc(16);
+        // Freed block has size >= 8192.
+        // Allocate LARGE from it. Remainder = 8192-2048-32 = 6112 >= 48 → splits.
+        void* small = kmalloc(LARGE);
         TEST_ASSERT("split: first part", small == big);
         // Second allocation should come from the split remainder
-        void* next = kmalloc(16);
+        void* next = kmalloc(LARGE);
         TEST_ASSERT("split: second from remainder", next != NULL);
-        // next should be right after small's block: small + 16 + HEADER_SIZE(32) = small + 48
-        unsigned long expected = (unsigned long)small + 16 + TEST_HEADER_SIZE;
+        // next should be right after small's block: small + LARGE + HEADER_SIZE
+        unsigned long expected = (unsigned long)small + LARGE + TEST_HEADER_SIZE;
         TEST_ASSERT("split: contiguous layout", (unsigned long)next == expected);
         kfree(small);
         kfree(next);
+        kfree(drain);
     }
     TEST_PASS("block splitting basic");
 
     // no split when remainder < header_size + 16 (48)
     //    If the remaining space after alloc is < 48 bytes, no split occurs.
-    //    We indirectly verify by checking that two allocs from a just-right
-    //    block still work.
     {
         // Allocate then free a block. Re-alloc the same size → no split expected.
-        void* p = kmalloc(64);
+        void* p = kmalloc(LARGE);
         kfree(p);
-        void* q = kmalloc(64);
+        void* q = kmalloc(LARGE);
         TEST_ASSERT("no-split same size reuse", q == p);
         kfree(q);
     }
     TEST_PASS("no unnecessary split");
 
-    // split creates usable blocks (write to both halves)
+    // split creates usable blocks (write to both halves, sizes > SLAB_MAX)
     {
-        void* big = kmalloc(512);
+        void* big = kmalloc(8192);
         kfree(big);
-        unsigned char* a = (unsigned char*)kmalloc(64);
-        unsigned char* b = (unsigned char*)kmalloc(64);
+        unsigned char* a = (unsigned char*)kmalloc(LARGE);
+        unsigned char* b = (unsigned char*)kmalloc(LARGE);
         // Write full patterns to both split parts
-        memset(a, 0x11, 64);
-        memset(b, 0x22, 64);
+        memset(a, 0x11, LARGE);
+        memset(b, 0x22, LARGE);
         int a_ok = 1, b_ok = 1;
-        for (int i = 0; i < 64; i++)
+        for (int i = 0; i < LARGE; i++)
         {
             if (a[i] != 0x11)
                 a_ok = 0;
@@ -227,38 +230,38 @@ void test_heap(void)
     }
     TEST_PASS("split blocks usable");
 
-    // repeated splitting exhausts a block correctly
+    // repeated splitting exhausts a block correctly (sizes > SLAB_MAX)
     {
-        void* big = kmalloc(1024);
+        void* big = kmalloc(8192);
         kfree(big);
-        // Each 16-byte alloc uses 16 + 32 = 48 bytes of the original block.
-        // From 1024 bytes, we can fit floor(1024 / 48) = 21 splits.
-        // (21 * 48 = 1008, remainder 16 < 48 so last one absorbs it)
-        void* ptrs[21];
+        // Each LARGE (2048) alloc uses 2048 + 32 = 2080 bytes.
+        // From 8192 bytes, we can fit floor(8192 / 2080) = 3 splits.
+        // (3 * 2080 = 6240, remainder 1952 < 2080+32 so 4th needs expansion)
+        void* ptrs[3];
         int count = 0;
-        for (int i = 0; i < 21; i++)
+        for (int i = 0; i < 3; i++)
         {
-            ptrs[i] = kmalloc(16);
+            ptrs[i] = kmalloc(LARGE);
             if (ptrs[i] != NULL)
                 count++;
         }
-        TEST_ASSERT("repeated split fills block", count == 21);
-        for (int i = 0; i < 21; i++)
+        TEST_ASSERT("repeated split fills block", count == 3);
+        for (int i = 0; i < 3; i++)
             kfree(ptrs[i]);
     }
     TEST_PASS("repeated splitting");
 
-    // coalescing
+    // coalescing (sizes > SLAB_MAX)
 
     // two adjacent free blocks coalesce
     {
-        void* a = kmalloc(64);
-        void* b = kmalloc(64);
-        void* guard = kmalloc(64); // prevent merging beyond b
+        void* a = kmalloc(LARGE);
+        void* b = kmalloc(LARGE);
+        void* guard = kmalloc(LARGE); // prevent merging beyond b
         kfree(a);
         kfree(b);
-        // a+b should coalesce: 64 + 32(header) + 64 = 160 usable
-        void* merged = kmalloc(160);
+        // a+b should coalesce: 2048 + 32(header) + 2048 = 4128 usable
+        void* merged = kmalloc(4128);
         TEST_ASSERT("coalesce: merged alloc succeeds", merged != NULL);
         TEST_ASSERT("coalesce: merged at a's position", merged == a);
         kfree(merged);
@@ -268,15 +271,15 @@ void test_heap(void)
 
     // three adjacent free blocks coalesce (chain)
     {
-        void* a = kmalloc(64);
-        void* b = kmalloc(64);
-        void* c = kmalloc(64);
-        void* guard = kmalloc(64);
+        void* a = kmalloc(LARGE);
+        void* b = kmalloc(LARGE);
+        void* c = kmalloc(LARGE);
+        void* guard = kmalloc(LARGE);
         kfree(a);
         kfree(b);
         kfree(c);
-        // Total coalesced usable = 64 + 32 + 64 + 32 + 64 = 256
-        void* merged = kmalloc(256);
+        // Total coalesced usable = 2048 + 32 + 2048 + 32 + 2048 = 6208
+        void* merged = kmalloc(6208);
         TEST_ASSERT("3-coalesce succeeds", merged != NULL);
         TEST_ASSERT("3-coalesce at a's position", merged == a);
         kfree(merged);
@@ -286,14 +289,14 @@ void test_heap(void)
 
     // non-adjacent free blocks do not coalesce
     {
-        void* a = kmalloc(64);
-        void* b = kmalloc(64); // stays allocated
-        void* c = kmalloc(64);
+        void* a = kmalloc(LARGE);
+        void* b = kmalloc(LARGE); // stays allocated
+        void* c = kmalloc(LARGE);
         kfree(a);
         kfree(c);
         // a and c are free but b separates them: should NOT coalesce
-        // Trying to alloc 160 should NOT reuse a (a is only 64)
-        void* big = kmalloc(160);
+        // Trying to alloc 4128 should NOT reuse a (a is only 2048)
+        void* big = kmalloc(4128);
         TEST_ASSERT("no false coalesce", big != a);
         kfree(big);
         kfree(b);
@@ -302,15 +305,15 @@ void test_heap(void)
 
     // coalesce then split: free two adjacent, alloc smaller
     {
-        void* a = kmalloc(64);
-        void* b = kmalloc(64);
-        void* guard = kmalloc(64);
+        void* a = kmalloc(LARGE);
+        void* b = kmalloc(LARGE);
+        void* guard = kmalloc(LARGE);
         kfree(a);
         kfree(b);
-        // Coalesced block = 160, alloc 32 from it → split (160-32-32=96 >= 48)
-        void* small = kmalloc(32);
+        // Coalesced block = 4128, alloc LARGE from it → split (4128-2048-32=2048 >= 48)
+        void* small = kmalloc(LARGE);
         TEST_ASSERT("coalesce+split: first part", small == a);
-        void* next = kmalloc(32);
+        void* next = kmalloc(LARGE);
         TEST_ASSERT("coalesce+split: second from remainder", next != NULL);
         kfree(small);
         kfree(next);
@@ -320,13 +323,13 @@ void test_heap(void)
 
     // free in reverse order still coalesces
     {
-        void* a = kmalloc(64);
-        void* b = kmalloc(64);
-        void* guard = kmalloc(64);
+        void* a = kmalloc(LARGE);
+        void* b = kmalloc(LARGE);
+        void* guard = kmalloc(LARGE);
         // Free in forward order vs reverse - coalescing walks the list
         kfree(b);
         kfree(a);
-        void* merged = kmalloc(160);
+        void* merged = kmalloc(4128);
         TEST_ASSERT("reverse free coalesces", merged != NULL);
         kfree(merged);
         kfree(guard);
@@ -827,19 +830,17 @@ void test_heap(void)
     }
     TEST_PASS("ALIGN boundary sizes");
 
-    // alloc sizes near split threshold
+    // alloc sizes near split threshold (sizes > SLAB_MAX)
     //    Split happens when remaining >= HEADER_SIZE(32) + 16 = 48.
-    //    Allocate from a 128-byte block with sizes that leave various remainders.
     {
-        // Make a free block of exactly 128 bytes usable space
-        // by allocating 128 then freeing
-        void* blk = kmalloc(128);
+        // Make a free block of usable space via alloc+free
+        void* blk = kmalloc(4096);
         kfree(blk);
 
-        // Alloc 80: remaining = 128 - 80 = 48 = HEADER(32) + 16 → SHOULD split
-        void* a = kmalloc(80);
-        void* split_part = kmalloc(16); // should come from split remainder
-        TEST_ASSERT("threshold: 80→split exists", split_part != NULL);
+        // Alloc LARGE: remaining = 4096-2048 = 2048 >= 48 → SHOULD split
+        void* a = kmalloc(LARGE);
+        void* split_part = kmalloc(LARGE); // should come from split remainder
+        TEST_ASSERT("threshold: split exists", split_part != NULL);
         kfree(a);
         kfree(split_part);
     }
@@ -883,20 +884,20 @@ void test_heap(void)
     }
     TEST_PASS("full lifecycle");
 
-    // complex multi-size lifecycle
+    // complex multi-size lifecycle (sizes > SLAB_MAX)
     {
         // Phase 1: allocate various sizes
-        void* a = kmalloc(32);
-        void* b = kmalloc(128);
-        void* c = kmalloc(64);
-        void* d = kmalloc(256);
+        void* a = kmalloc(LARGE);
+        void* b = kmalloc(4096);
+        void* c = kmalloc(LARGE);
+        void* d = kmalloc(8192);
 
         // Phase 2: free middle ones, creating holes
         kfree(b);
         kfree(c);
 
         // Phase 3: alloc into holes (first-fit into b's old slot)
-        void* e = kmalloc(64);
+        void* e = kmalloc(LARGE);
         TEST_ASSERT("lifecycle2: reuse b slot", e == b);
 
         // Phase 4: free everything
@@ -905,7 +906,7 @@ void test_heap(void)
         kfree(d);
 
         // Phase 5: large alloc should succeed (coalesced space)
-        void* f = kmalloc(512);
+        void* f = kmalloc(8192);
         TEST_ASSERT("lifecycle2: post-coalesce", f != NULL);
         kfree(f);
     }

--- a/src/test/test_slab.c
+++ b/src/test/test_slab.c
@@ -1,0 +1,237 @@
+#include "test.h"
+#include "kernel/slab.h"
+#include "kernel/heap.h"
+#include "lib/string.h"
+#include "lib/types.h"
+
+void test_slab(void)
+{
+    TEST_SUITE_BEGIN("Slab Allocator");
+
+    // basic alloc / free for each size class
+    {
+        unsigned long sizes[] = {1, 16, 32, 64, 128, 256, 512, 1024};
+        int n = sizeof(sizes) / sizeof(sizes[0]);
+        for (int i = 0; i < n; i++)
+        {
+            void* p = kmalloc(sizes[i]);
+            TEST_ASSERT("slab alloc non-null", p != NULL);
+            TEST_ASSERT("slab 16-byte aligned", ((unsigned long)p & 0xF) == 0);
+            kfree(p);
+        }
+    }
+    TEST_PASS("basic alloc/free all classes");
+
+    // LIFO reuse: free then re-alloc same size returns same pointer
+    {
+        void* p1 = kmalloc(64);
+        kfree(p1);
+        void* p2 = kmalloc(64);
+        TEST_ASSERT("slab LIFO reuse", p2 == p1);
+        kfree(p2);
+    }
+    TEST_PASS("LIFO reuse");
+
+    // all slots distinct within a size class
+    {
+        void* ptrs[64];
+        for (int i = 0; i < 64; i++)
+        {
+            ptrs[i] = kmalloc(32);
+            TEST_ASSERT("slab 64x alloc", ptrs[i] != NULL);
+        }
+        int distinct = 1;
+        for (int i = 0; i < 64 && distinct; i++)
+            for (int j = i + 1; j < 64 && distinct; j++)
+                if (ptrs[i] == ptrs[j])
+                    distinct = 0;
+        TEST_ASSERT("slab all 64 distinct", distinct);
+        for (int i = 0; i < 64; i++)
+            kfree(ptrs[i]);
+    }
+    TEST_PASS("64 allocs distinct");
+
+    // data isolation between adjacent slab slots
+    {
+        unsigned char* a = (unsigned char*)kmalloc(64);
+        unsigned char* b = (unsigned char*)kmalloc(64);
+        memset(a, 0xAA, 64);
+        memset(b, 0xBB, 64);
+        int a_ok = 1, b_ok = 1;
+        for (int i = 0; i < 64; i++)
+        {
+            if (a[i] != 0xAA)
+                a_ok = 0;
+            if (b[i] != 0xBB)
+                b_ok = 0;
+        }
+        TEST_ASSERT("slab block a intact", a_ok);
+        TEST_ASSERT("slab block b intact", b_ok);
+        kfree(a);
+        kfree(b);
+    }
+    TEST_PASS("data isolation");
+
+    // slab_owns correctly identifies slab pointers
+    {
+        void* slab_ptr = kmalloc(64);
+        void* heap_ptr = kmalloc(4096); // > 1024, goes to first-fit
+        TEST_ASSERT("slab_owns slab ptr", slab_owns(slab_ptr) == 1);
+        TEST_ASSERT("slab_owns heap ptr", slab_owns(heap_ptr) == 0);
+        TEST_ASSERT("slab_owns null", slab_owns(NULL) == 0);
+        kfree(slab_ptr);
+        kfree(heap_ptr);
+    }
+    TEST_PASS("slab_owns dispatch");
+
+    // cross-class allocations don't interfere
+    {
+        unsigned char* p16 = (unsigned char*)kmalloc(16);
+        unsigned char* p64 = (unsigned char*)kmalloc(64);
+        unsigned char* p256 = (unsigned char*)kmalloc(256);
+        unsigned char* p1024 = (unsigned char*)kmalloc(1024);
+        memset(p16, 0x11, 16);
+        memset(p64, 0x22, 64);
+        memset(p256, 0x33, 256);
+        memset(p1024, 0x44, 1024);
+        int ok = 1;
+        for (int i = 0; i < 16; i++)
+            if (p16[i] != 0x11)
+                ok = 0;
+        for (int i = 0; i < 64; i++)
+            if (p64[i] != 0x22)
+                ok = 0;
+        for (int i = 0; i < 256; i++)
+            if (p256[i] != 0x33)
+                ok = 0;
+        for (int i = 0; i < 1024; i++)
+            if (p1024[i] != 0x44)
+                ok = 0;
+        TEST_ASSERT("cross-class data intact", ok);
+        kfree(p16);
+        kfree(p64);
+        kfree(p256);
+        kfree(p1024);
+    }
+    TEST_PASS("cross-class isolation");
+
+    // slab grows automatically when a page fills up
+    // 16-byte class: ~254 slots per page (4096 - header) / 16
+    {
+        void* ptrs[300];
+        int count = 0;
+        for (int i = 0; i < 300; i++)
+        {
+            ptrs[i] = kmalloc(16);
+            if (ptrs[i] != NULL)
+                count++;
+        }
+        TEST_ASSERT("slab auto-grow 300 allocs", count == 300);
+        for (int i = 0; i < 300; i++)
+            kfree(ptrs[i]);
+    }
+    TEST_PASS("auto-grow beyond one page");
+
+    // rapid alloc/free cycle (stress)
+    {
+        for (int i = 0; i < 500; i++)
+        {
+            void* p = kmalloc(128);
+            TEST_ASSERT("slab rapid alloc", p != NULL);
+            *(volatile unsigned long*)p = 0xCAFEBABEUL;
+            TEST_ASSERT("slab rapid canary", *(volatile unsigned long*)p == 0xCAFEBABEUL);
+            kfree(p);
+        }
+    }
+    TEST_PASS("rapid cycle x500");
+
+    // fill-and-drain: alloc many, free all, alloc again
+    {
+        void* ptrs[128];
+        for (int i = 0; i < 128; i++)
+        {
+            ptrs[i] = kmalloc(64);
+            TEST_ASSERT("slab fill alloc", ptrs[i] != NULL);
+        }
+        for (int i = 127; i >= 0; i--)
+            kfree(ptrs[i]);
+
+        // After draining, allocator should still work
+        void* p = kmalloc(64);
+        TEST_ASSERT("slab post-drain alloc", p != NULL);
+        kfree(p);
+    }
+    TEST_PASS("fill-and-drain 128");
+
+    // mixed slab + first-fit: interleaved small/large allocations
+    {
+        void* s1 = kmalloc(16);
+        void* l1 = kmalloc(4096);
+        void* s2 = kmalloc(512);
+        void* l2 = kmalloc(8192);
+        void* s3 = kmalloc(1024);
+        TEST_ASSERT("mixed s1", s1 != NULL);
+        TEST_ASSERT("mixed l1", l1 != NULL);
+        TEST_ASSERT("mixed s2", s2 != NULL);
+        TEST_ASSERT("mixed l2", l2 != NULL);
+        TEST_ASSERT("mixed s3", s3 != NULL);
+        kfree(s2);
+        kfree(l1);
+        kfree(s1);
+        kfree(l2);
+        kfree(s3);
+    }
+    TEST_PASS("mixed slab+first-fit");
+
+    // boundary: size exactly at each class boundary
+    {
+        unsigned long exact[] = {16, 32, 64, 128, 256, 512, 1024};
+        int n = sizeof(exact) / sizeof(exact[0]);
+        void* ptrs[7];
+        for (int i = 0; i < n; i++)
+        {
+            ptrs[i] = kmalloc(exact[i]);
+            TEST_ASSERT("exact class alloc", ptrs[i] != NULL);
+            memset(ptrs[i], (unsigned char)(i + 1), exact[i]);
+        }
+        int ok = 1;
+        for (int i = 0; i < n; i++)
+        {
+            unsigned char* cp = (unsigned char*)ptrs[i];
+            for (unsigned long j = 0; j < exact[i]; j++)
+                if (cp[j] != (unsigned char)(i + 1))
+                    ok = 0;
+        }
+        TEST_ASSERT("exact class data intact", ok);
+        for (int i = 0; i < n; i++)
+            kfree(ptrs[i]);
+    }
+    TEST_PASS("exact class boundaries");
+
+    // boundary: size one byte above each class → promoted to next class
+    {
+        unsigned long above[] = {17, 33, 65, 129, 257, 513};
+        int n = sizeof(above) / sizeof(above[0]);
+        void* ptrs[6];
+        for (int i = 0; i < n; i++)
+        {
+            ptrs[i] = kmalloc(above[i]);
+            TEST_ASSERT("above-class alloc", ptrs[i] != NULL);
+            memset(ptrs[i], 0xDD, above[i]);
+        }
+        int ok = 1;
+        for (int i = 0; i < n; i++)
+        {
+            unsigned char* cp = (unsigned char*)ptrs[i];
+            for (unsigned long j = 0; j < above[i]; j++)
+                if (cp[j] != 0xDD)
+                    ok = 0;
+        }
+        TEST_ASSERT("above-class data intact", ok);
+        for (int i = 0; i < n; i++)
+            kfree(ptrs[i]);
+    }
+    TEST_PASS("class promotion");
+
+    TEST_SUITE_END("Slab Allocator");
+}


### PR DESCRIPTION
implemented a hybrid  O(1) slub memory allocator for blocks <1024 bytes with 7 classes: {16, 32, 64, 128, 256, 512, 1024}